### PR TITLE
Test improvements for the EXCLUDEEMPTY tests (redis/jedis#4641)

### DIFF
--- a/src/test/java/io/redis/test/utils/RedisVersion.java
+++ b/src/test/java/io/redis/test/utils/RedisVersion.java
@@ -11,6 +11,8 @@ public class RedisVersion implements Comparable<RedisVersion> {
     public static final RedisVersion V8_4_0 = RedisVersion.of("8.4.0");
     public static final RedisVersion V8_6_0 = RedisVersion.of("8.6.0");
     public static final RedisVersion V8_6_1 = RedisVersion.of("8.6.1");
+    public static final String V8_10_0_RC2_STRING = "8.9.241";
+    public static final RedisVersion V8_10_0_RC2 = RedisVersion.of(V8_10_0_RC2_STRING);
 
     private final int major;
     private final int minor;

--- a/src/test/java/redis/clients/jedis/commands/unified/UnifiedJedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/UnifiedJedisCommandsTestBase.java
@@ -4,6 +4,7 @@ package redis.clients.jedis.commands.unified;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.BeforeAll;
 import redis.clients.jedis.EndpointConfig;
@@ -14,6 +15,7 @@ import redis.clients.jedis.commands.CommandsTestsParameters;
 import redis.clients.jedis.util.EnabledOnCommandCondition;
 import redis.clients.jedis.util.EnvCondition;
 import redis.clients.jedis.util.RedisVersionCondition;
+import redis.clients.jedis.util.TestKeyRegistry;
 
 @Tag("integration")
 public abstract class UnifiedJedisCommandsTestBase {
@@ -27,6 +29,13 @@ public abstract class UnifiedJedisCommandsTestBase {
   protected final RedisProtocol protocol;
 
   protected UnifiedJedis jedis;
+
+  /**
+   * Per-test registry for unique key names on the shared test endpoints. Keys created via
+   * {@code keys.key(...)} are namespaced by test and deleted automatically after each test;
+   * tests that don't use it are unaffected.
+   */
+  protected TestKeyRegistry keys;
 
   protected static EndpointConfig endpoint;
 
@@ -69,7 +78,8 @@ public abstract class UnifiedJedisCommandsTestBase {
   }
 
   @BeforeEach
-  void setUpBase() {
+  void setUpBase(TestInfo testInfo) {
+    keys = TestKeyRegistry.create(testInfo);
     jedis = createTestClient();
     clearData();
   }
@@ -77,6 +87,7 @@ public abstract class UnifiedJedisCommandsTestBase {
   @AfterEach
   void tearDownBase() {
     if (jedis != null) {
+      keys.cleanup(jedis);
       jedis.close();
     }
   }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1579,33 +1579,45 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertTrue(revRanges.isEmpty());
   }
 
-  private String s, t, u, sensorFilter;
-
   /**
-   * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
-   * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
-   * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
+   * The three series from the EXCLUDEEMPTY design document examples, all matched by
+   * {@link #filter}.
    */
-  private void setupExcludeEmptySeries() {
-    s = keys.key("s");
-    t = keys.key("t");
-    u = keys.key("u");
+  private static final class ExcludeEmptyFixture {
+    final String seriesS; // samples at 100, 200, 400
+    final String seriesT; // samples at 100, 300, 400
+    final String seriesU; // only sample at 2000 — empty for any range bounded at 500
+    final String filter; // label filter matching all three, unique per test
+
+    ExcludeEmptyFixture(String seriesS, String seriesT, String seriesU, String filter) {
+      this.seriesS = seriesS;
+      this.seriesT = seriesT;
+      this.seriesU = seriesU;
+      this.filter = filter;
+    }
+  }
+
+  private ExcludeEmptyFixture setupExcludeEmptyFixture() {
+    String seriesS = keys.key("s");
+    String seriesT = keys.key("t");
+    String seriesU = keys.key("u");
     // MRANGE matches by label, so the filter value must be test-unique as well
     String sensor = keys.key("sensor");
-    sensorFilter = "sensor=" + sensor;
 
     Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
-    jedis.tsCreate(s, TSCreateParams.createParams().labels(labels));
-    jedis.tsCreate(t, TSCreateParams.createParams().labels(labels));
-    jedis.tsCreate(u, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesS, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesT, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesU, TSCreateParams.createParams().labels(labels));
 
-    jedis.tsAdd(s, 100, 100);
-    jedis.tsAdd(t, 100, 100);
-    jedis.tsAdd(s, 200, 200);
-    jedis.tsAdd(t, 300, 300);
-    jedis.tsAdd(s, 400, 400);
-    jedis.tsAdd(t, 400, 400);
-    jedis.tsAdd(u, 2000, 2000);
+    jedis.tsAdd(seriesS, 100, 100);
+    jedis.tsAdd(seriesT, 100, 100);
+    jedis.tsAdd(seriesS, 200, 200);
+    jedis.tsAdd(seriesT, 300, 300);
+    jedis.tsAdd(seriesS, 400, 400);
+    jedis.tsAdd(seriesT, 400, 400);
+    jedis.tsAdd(seriesU, 2000, 2000);
+
+    return new ExcludeEmptyFixture(seriesS, seriesT, seriesU, "sensor=" + sensor);
   }
 
   /**
@@ -1617,26 +1629,26 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     // Default: matching series u is still reported, with an empty samples array.
     Map<String, TSMRangeElements> included = jedis.tsMRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(sensorFilter));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(fixture.filter));
     assertEquals(3, included.size());
-    assertTrue(included.containsKey(u));
-    assertTrue(included.get(u).getValue().isEmpty());
+    assertTrue(included.containsKey(fixture.seriesU));
+    assertTrue(included.get(fixture.seriesU).getValue().isEmpty());
 
     // EXCLUDEEMPTY: series u is omitted from the reply; s and t are unchanged.
     Map<String, TSMRangeElements> excluded = jedis.tsMRange(TSMRangeParams.multiRangeParams()
-        .toTimestamp(500L).withLabels().excludeEmpty().filter(sensorFilter));
+        .toTimestamp(500L).withLabels().excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(200, 200), new TSElement(400, 400)),
-      excluded.get(s).getValue());
+      excluded.get(fixture.seriesS).getValue());
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(300, 300), new TSElement(400, 400)),
-      excluded.get(t).getValue());
+      excluded.get(fixture.seriesT).getValue());
   }
 
   /**
@@ -1646,16 +1658,16 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRevRangeExcludeEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     Map<String, TSMRangeElements> excluded = jedis.tsMRevRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(sensorFilter));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
     // Samples inside each returned series are ordered in reverse timestamp order.
     assertEquals(
       Arrays.asList(new TSElement(400, 400), new TSElement(200, 200), new TSElement(100, 100)),
-      excluded.get(s).getValue());
+      excluded.get(fixture.seriesS).getValue());
   }
 
   /**
@@ -1665,13 +1677,13 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyWithAggregation() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     Map<String, TSMRangeElements> excluded = jedis
         .tsMRange(TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels()
-            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(sensorFilter));
+            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
   }
 
   /**
@@ -1680,11 +1692,11 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyAllEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     // No matching series has a sample in [1, 50].
     Map<String, TSMRangeElements> excluded = jedis
-        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(sensorFilter));
+        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(fixture.filter));
     assertNotNull(excluded);
     assertTrue(excluded.isEmpty());
   }
@@ -1706,11 +1718,11 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void rawMRangeExcludeEmptyWithGroupByPropagatesServerError() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     JedisDataException error = assertThrows(JedisDataException.class,
       () -> jedis.sendCommand(TimeSeriesProtocol.TimeSeriesCommand.MRANGE, "-", "500",
-        "EXCLUDEEMPTY", "FILTER", sensorFilter, "GROUPBY", "type", "REDUCE", "max"));
+        "EXCLUDEEMPTY", "FILTER", fixture.filter, "GROUPBY", "type", "REDUCE", "max"));
     assertTrue(error.getMessage().contains("EXCLUDEEMPTY"),
       "Server error must be propagated as-is, was: " + error.getMessage());
   }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1580,8 +1580,9 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   /**
-   * The three series from the EXCLUDEEMPTY design document examples, all matched by
-   * {@link #filter}.
+   * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
+   * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
+   * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
    */
   private static final class ExcludeEmptyFixture {
     final String seriesS; // samples at 100, 200, 400
@@ -1602,7 +1603,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     String seriesT = keys.key("t");
     String seriesU = keys.key("u");
     // MRANGE matches by label, so the filter value must be test-unique as well
-    String sensor = keys.key("sensor");
+    String sensor = keys.name("sensor");
 
     Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
     jedis.tsCreate(seriesS, TSCreateParams.createParams().labels(labels));

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.redis.test.utils.RedisVersion.V8_10_0_RC2_STRING;
 import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
 
@@ -1614,7 +1615,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * option is what makes the difference (R.1, NF.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmpty() {
     setupExcludeEmptySeries();
 
@@ -1643,7 +1644,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * for the series that remain (R.1, R.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRevRangeExcludeEmpty() {
     setupExcludeEmptySeries();
 
@@ -1662,7 +1663,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * requested range and aggregation is omitted (R.5, NF.2).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyWithAggregation() {
     setupExcludeEmptySeries();
 
@@ -1677,7 +1678,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * When every matching series is empty, EXCLUDEEMPTY yields an empty top-level reply (R.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyAllEmpty() {
     setupExcludeEmptySeries();
 
@@ -1703,7 +1704,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * error propagated as-is (R.4, R.6).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void rawMRangeExcludeEmptyWithGroupByPropagatesServerError() {
     setupExcludeEmptySeries();
 

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1578,26 +1578,33 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertTrue(revRanges.isEmpty());
   }
 
+  private String s, t, u, sensorFilter;
+
   /**
    * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
    * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
    * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
    */
   private void setupExcludeEmptySeries() {
-    jedis.tsCreate("s",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
-    jedis.tsCreate("t",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
-    jedis.tsCreate("u",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
+    s = keys.key("s");
+    t = keys.key("t");
+    u = keys.key("u");
+    // MRANGE matches by label, so the filter value must be test-unique as well
+    String sensor = keys.key("sensor");
+    sensorFilter = "sensor=" + sensor;
 
-    jedis.tsAdd("s", 100, 100);
-    jedis.tsAdd("t", 100, 100);
-    jedis.tsAdd("s", 200, 200);
-    jedis.tsAdd("t", 300, 300);
-    jedis.tsAdd("s", 400, 400);
-    jedis.tsAdd("t", 400, 400);
-    jedis.tsAdd("u", 2000, 2000);
+    Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
+    jedis.tsCreate(s, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(t, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(u, TSCreateParams.createParams().labels(labels));
+
+    jedis.tsAdd(s, 100, 100);
+    jedis.tsAdd(t, 100, 100);
+    jedis.tsAdd(s, 200, 200);
+    jedis.tsAdd(t, 300, 300);
+    jedis.tsAdd(s, 400, 400);
+    jedis.tsAdd(t, 400, 400);
+    jedis.tsAdd(u, 2000, 2000);
   }
 
   /**
@@ -1613,22 +1620,22 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     // Default: matching series u is still reported, with an empty samples array.
     Map<String, TSMRangeElements> included = jedis.tsMRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter("sensor=1"));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(sensorFilter));
     assertEquals(3, included.size());
-    assertTrue(included.containsKey("u"));
-    assertTrue(included.get("u").getValue().isEmpty());
+    assertTrue(included.containsKey(u));
+    assertTrue(included.get(u).getValue().isEmpty());
 
     // EXCLUDEEMPTY: series u is omitted from the reply; s and t are unchanged.
     Map<String, TSMRangeElements> excluded = jedis.tsMRange(TSMRangeParams.multiRangeParams()
-        .toTimestamp(500L).withLabels().excludeEmpty().filter("sensor=1"));
+        .toTimestamp(500L).withLabels().excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(200, 200), new TSElement(400, 400)),
-      excluded.get("s").getValue());
+      excluded.get(s).getValue());
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(300, 300), new TSElement(400, 400)),
-      excluded.get("t").getValue());
+      excluded.get(t).getValue());
   }
 
   /**
@@ -1641,13 +1648,13 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     setupExcludeEmptySeries();
 
     Map<String, TSMRangeElements> excluded = jedis.tsMRevRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter("sensor=1"));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
     // Samples inside each returned series are ordered in reverse timestamp order.
     assertEquals(
       Arrays.asList(new TSElement(400, 400), new TSElement(200, 200), new TSElement(100, 100)),
-      excluded.get("s").getValue());
+      excluded.get(s).getValue());
   }
 
   /**
@@ -1661,9 +1668,9 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     Map<String, TSMRangeElements> excluded = jedis
         .tsMRange(TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels()
-            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter("sensor=1"));
+            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
   }
 
   /**
@@ -1676,7 +1683,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     // No matching series has a sample in [1, 50].
     Map<String, TSMRangeElements> excluded = jedis
-        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter("sensor=1"));
+        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(sensorFilter));
     assertNotNull(excluded);
     assertTrue(excluded.isEmpty());
   }
@@ -1702,7 +1709,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     JedisDataException error = assertThrows(JedisDataException.class,
       () -> jedis.sendCommand(TimeSeriesProtocol.TimeSeriesCommand.MRANGE, "-", "500",
-        "EXCLUDEEMPTY", "FILTER", "sensor=1", "GROUPBY", "type", "REDUCE", "max"));
+        "EXCLUDEEMPTY", "FILTER", sensorFilter, "GROUPBY", "type", "REDUCE", "max"));
     assertTrue(error.getMessage().contains("EXCLUDEEMPTY"),
       "Server error must be propagated as-is, was: " + error.getMessage());
   }

--- a/src/test/java/redis/clients/jedis/util/TestKeyRegistry.java
+++ b/src/test/java/redis/clients/jedis/util/TestKeyRegistry.java
@@ -74,6 +74,13 @@ public interface TestKeyRegistry {
    */
   byte[] bKey(String pattern);
 
+  /**
+   * Returns a test-unique name derived from the given pattern (same rules as {@link #key(String)})
+   * without registering it for cleanup. For resources that are not Redis keys — label values, group
+   * or consumer names — or keys whose cleanup is handled elsewhere.
+   */
+  String name(String pattern);
+
   /** Registers an externally-created key for cleanup and returns it. Duplicates are ignored. */
   String register(String key);
 
@@ -120,6 +127,11 @@ public interface TestKeyRegistry {
     @Override
     public byte[] bKey(String pattern) {
       return register(SafeEncoder.encode(expand(pattern)));
+    }
+
+    @Override
+    public String name(String pattern) {
+      return expand(pattern);
     }
 
     @Override


### PR DESCRIPTION
## What
Test-only improvements for the new EXCLUDEEMPTY integration tests in redis/jedis#4641: unique per-test keys with automatic cleanup, an explicit test fixture, and a named version constant.

## Why
The new tests create series with collision-prone names (`s`, `t`, `u`) and discover them via a shared label filter (`sensor=1`) on the shared test endpoints, pass state from the setup helper through mutable fields, and version-gate on the raw internal build number `8.9.241`. This adopts the `TestKeyRegistry` pattern introduced in redis/jedis#4644 so the tests are isolated and self-documenting.

## Changes
- `UnifiedJedisCommandsTestBase`: expose a per-test `TestKeyRegistry keys` (created in `@BeforeEach`, cleaned up before `jedis.close()` in `@AfterEach`). Opt-in — tests that register nothing get a no-op cleanup, so existing tests are unaffected.
- EXCLUDEEMPTY tests: series keys and the sensor label value are test-unique, so MRANGE label filters cannot match series leaked by other suites.
- Replace the mutable `s`/`t`/`u`/`sensorFilter` fields with an immutable `ExcludeEmptyFixture` returned by `setupExcludeEmptyFixture()`, documenting the sample layout next to the names the assertions use.
- Extract `8.9.241` into `RedisVersion.V8_10_0_RC2_STRING` / `V8_10_0_RC2` (8.10.0 RC2 reports `redis_version` 8.9.241).
- `TestKeyRegistry`: add `name(pattern)` — same expansion rules as `key()` without registering for cleanup, for test-unique values that are not Redis keys (label values, group/consumer names).